### PR TITLE
Include button name/value in form submissions. Full application/xhtml+xml support.

### DIFF
--- a/lib/mu.js
+++ b/lib/mu.js
@@ -883,14 +883,14 @@ var mu = mu || new function() {
 			return;
 		cfg._sourceElement = form;
 		e.preventDefault();
+		var formData = new FormData(form, e.submitter);
 		if (method === "get") {
-			var formData = new FormData(form);
 			var qs = new URLSearchParams(formData).toString();
 			url = url + "?" + qs;
 		} else {
 			cfg.postData = (form.enctype === "multipart/form-data")
-			               ? new FormData(form)
-			               : new URLSearchParams(new FormData(form));
+			               ? formData
+			               : new URLSearchParams(formData);
 			// Non-GET forms: no history by default, scroll to top in navigation mode
 			if (mu._attr(form, "history") === null)
 				cfg.history = false;


### PR DESCRIPTION
Hi again,

I have a couple more bug fixes if you want them.

1) compare all tagName using toUpperCase **except** body. replaceWith() works on body elements in application/xhtml+xml and should be used there.

2) include the submit button's name/value on the submitted form data.